### PR TITLE
chore: removes v1 from endpoint in favour of dynamic version policy

### DIFF
--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -15,7 +15,7 @@ pub(crate) trait SantaSyncServerApi {
 
     #[endpoint(
         method = POST,
-        path = "/v1/preflight/{machine_id}",
+        path = "/preflight/{machine_id}",
         content_type = "application/json",
     )]
     async fn preflight_post(
@@ -26,7 +26,7 @@ pub(crate) trait SantaSyncServerApi {
 
     #[endpoint(
         method = POST,
-        path = "/v1/eventupload/{machine_id}",
+        path = "/eventupload/{machine_id}",
         content_type = "application/json",
     )]
     async fn eventupload_post(
@@ -37,7 +37,7 @@ pub(crate) trait SantaSyncServerApi {
 
     #[endpoint(
         method = POST,
-        path = "/v1/ruledownload/{machine_id}",
+        path = "/ruledownload/{machine_id}",
         content_type = "application/json",
     )]
     async fn ruledownload_post(
@@ -47,7 +47,7 @@ pub(crate) trait SantaSyncServerApi {
 
     #[endpoint(
         method = POST,
-        path = "/v1/postflight/{machine_id}",
+        path = "/postflight/{machine_id}",
         content_type = "application/json",
     )]
     async fn postflight_post(

--- a/server/tests/integration-tests/eventupload.rs
+++ b/server/tests/integration-tests/eventupload.rs
@@ -4,7 +4,7 @@ use crate::test_util::{
     build_request, ContentEncoding, EventLogMode, MachineId, TestContext, DEFAULT_CONFIG_PATH,
 };
 
-const PREFIX_URI: &str = "/v1/eventupload";
+const PREFIX_URI: &str = "/eventupload";
 const DEFAULT_REQUEST_BODY: &str = r#"{
     "events": [{
         "file_sha256": "file_sha256",

--- a/server/tests/integration-tests/load_test.rs
+++ b/server/tests/integration-tests/load_test.rs
@@ -49,7 +49,7 @@ const DEFAULT_EVENTUPLOAD_BODY: &str = r#"{
 
 #[allow(dead_code)]
 fn build_uri(machine_id: &str) -> String {
-    format!("/v1/eventupload/{}", machine_id)
+    format!("/eventupload/{}", machine_id)
 }
 
 #[tokio::test]

--- a/server/tests/integration-tests/postflight.rs
+++ b/server/tests/integration-tests/postflight.rs
@@ -2,7 +2,7 @@ use crate::test_util::{
     build_request, ContentEncoding, EventLogMode, MachineId, TestContext, DEFAULT_CONFIG_PATH,
 };
 
-const PREFIX_URI: &str = "/v1/postflight";
+const PREFIX_URI: &str = "/postflight";
 
 fn build_uri(machine_id: &str) -> String {
     format!("{}/{}", PREFIX_URI, machine_id)

--- a/server/tests/integration-tests/preflight.rs
+++ b/server/tests/integration-tests/preflight.rs
@@ -4,7 +4,7 @@ use crate::test_util::{
     build_request, ContentEncoding, EventLogMode, MachineId, TestContext, DEFAULT_CONFIG_PATH,
 };
 
-const PREFIX_URI: &str = "/v1/preflight";
+const PREFIX_URI: &str = "/preflight";
 
 fn build_uri(machine_id: &str) -> String {
     format!("{}/{}", PREFIX_URI, machine_id)

--- a/server/tests/integration-tests/ruledownload.rs
+++ b/server/tests/integration-tests/ruledownload.rs
@@ -4,7 +4,7 @@ use crate::test_util::{
     build_request, ContentEncoding, EventLogMode, MachineId, TestContext, DEFAULT_CONFIG_PATH,
 };
 
-const PREFIX_URI: &str = "/v1/ruledownload";
+const PREFIX_URI: &str = "/ruledownload";
 
 fn build_uri(machine_id: &str) -> String {
     format!("{}/{}", PREFIX_URI, machine_id)


### PR DESCRIPTION
For future: https://docs.rs/dropshot/latest/dropshot/#api-versioning